### PR TITLE
changes from USAGE_NOTIFICATION to USAGE_ALARM for all notifications

### DIFF
--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
@@ -972,7 +972,7 @@ public class FlutterLocalNotificationsPlugin
       notificationChannel.setGroup(notificationChannelDetails.groupId);
       if (notificationChannelDetails.playSound) {
         AudioAttributes audioAttributes =
-            new AudioAttributes.Builder().setUsage(AudioAttributes.USAGE_NOTIFICATION).build();
+            new AudioAttributes.Builder().setUsage(AudioAttributes.USAGE_ALARM).build();
         Uri uri =
             retrieveSoundResourceUri(
                 context, notificationChannelDetails.sound, notificationChannelDetails.soundSource);


### PR DESCRIPTION
Note that there is also a possibility to set STREAM_ALARM as a parameter in the "setSound" method. This seems to make it possible to set per notification, easily. However, it appears that the setting doesn't do anything.
