### PR TITLE
SGC-2910 fix Flutter 3.24 ambiguous method call error

### DIFF
--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
@@ -1038,7 +1038,7 @@ public class FlutterLocalNotificationsPlugin
     }
 
     if (bigPictureStyleInformation.hideExpandedLargeIcon) {
-      bigPictureStyle.bigLargeIcon(null);
+      bigPictureStyle.bigLargeIcon((Bitmap) null);
     } else {
       if (bigPictureStyleInformation.largeIcon != null) {
         bigPictureStyle.bigLargeIcon(


### PR DESCRIPTION
Clone of main repo fix: https://github.com/MaikuB/flutter_local_notifications/pull/2355

Read here for more info on the issue: https://github.com/MaikuB/flutter_local_notifications/issues/2329